### PR TITLE
Codespaces Port forwarding URL support

### DIFF
--- a/.auth0/lab/guides/client-secrets-and-access-tokens.tour
+++ b/.auth0/lab/guides/client-secrets-and-access-tokens.tour
@@ -3,7 +3,7 @@
   "title": "4: Client Secrets and Access Tokens",
   "steps": [
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Add the Client Secret to Your Environment",
       "description": "## Add the Client Secret to Your Environment\nNow let’s use an Access Token to call the Expenses API.\n\nCurrently, the Web Application is set up to perform authentication based on the OpenID Connect standard. \n\nTo access a secured resource like the expenses API, a client needs an Access Token. This will require the application to communicate with the token endpoint on the authorization server.\n\nTo accomplish this, the Web Application will use the Authorization Code Flow. This flow requires full client credentials from a calling application. At this point, we only have the Client ID.\n\nWhat we're missing is a Client Secret.\n\nThe _clientSecret:_ is created on the authorization server (Auth0) along with the Client ID and is a unique string that is used to authenticate an application. \n\nThis secret must be provided in each request when requesting access tokens.  \n\nWe'll retrieve the clientSecret and store it locally in an environment variable called _CLIENT_SECRET_.\n\n1. #### (optional) View the Client Secret in the Auth0 Dashboard. \n    You can find the Client Secret in the Auth0 Dashboard for your tenant. \n\n    1. Browse to it at [Applications page](https://manage.auth0.com/#/applications), and click into your web application's settings.  \n\n    1. On the _Settings_ tab, you can see the _Client Secret_.\n\n    ![](https://cdn.auth0.com/website/training/example/A0FUN-M06-L01/img-1.png)  \n\n1. #### Retrieve the Client Secret.\n    1. Click [here](command:auth0.lab.localConfigure) to issue a command via the Auth0 extension for vscode and the CLI to reach out to your labs tenant and retrieve the configuration values for your Web App and Expenses API.\n     1. Click [here](command:workbench.action.files.saveAll) to save all of these changes.\n\nWith the environment now configured with the Client Secret, you're ready to configure the Web Application to request a Token."
@@ -69,7 +69,7 @@
       }
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Nice Work!",
       "description": "## Nice Work!\nThe next time you log in to your web application and attempt to navigate to the expenses, you will see the list of expenses without error. (Be sure that you log out of the app completely before logging back in.)\n\n#### Let's give it a try!\n\n1. #### Run the Web Application and Expenses API.\n    1. Click [here](command:workbench.action.files.saveFiles) to save all this progress.\n    1. Click [here](command:workbench.action.terminal.new) to open your vscode terminal. (You may already have one open, that's ok.)\n    1. Click [here](command:workbench.action.debug.start) to build and redeploy the Web Application and Expenses API.\n    1. Click [here](command:auth0.lab.openEndpointByName?[\"Lab: Web App, Lab: API\"]) to re-launch the Web Application and the Expenses API in your web browser.\n1. #### Log out of the Web App (If you're still logged in.).\n1. #### Log back in, and navigate to the Expenses section.\n\nCongratulations! You should be able to view the expenses, which are now being securely retrieved by the Web Application from the Expenses API!"

--- a/.auth0/lab/guides/configure-the-web-application-to-pull-expenses-from-the-api.tour
+++ b/.auth0/lab/guides/configure-the-web-application-to-pull-expenses-from-the-api.tour
@@ -3,13 +3,13 @@
   "title": "2: Configure the Web Application to Pull Expenses from the API",
   "steps": [
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "What You'll Learn",
       "description": "## You just:\n1. Registered the Expenses API in your Tenant.\n\n## Now you will:\n1. Deploy a test API into the lab environment.\n1. Modify the Web application to call the API.\n1. Obtain a test Access Token.\n1. Call the test API using the Access Token."
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Check the 'src' Folder",
       "description": "## Check the 'src' Folder\nIf you [examine the Explorer pane](command:workbench.explorer.fileView.focus) you'll notice that we've added a new folder in addition to the web-app folder from previous labs. \n\n*You can navigate to the explorer pane, Auth0 plugin and other areas in VS Code using the Activity bar. Here's a quick intro to the user interface if you need it: [VS Code UI](https://code.visualstudio.com/docs/getstarted/userinterface).*\n\nUp until this point, the expenses that your web-application displays to users have been hard-coded into the application. We're going to change that.\n\nIn the src folder, you'll now see an 'api' folder containing an entirely different application -- Our new API! \n\nThe first step will be wiring these two applications together. Let's get started!"
@@ -75,7 +75,7 @@
       }
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Run the Application and API",
       "description": "## Run the Web App and API\nNow that we've connected the Expenses Web Application to our Expenses API, let's run them both and take a look. \n\n1. #### Run the API\n    1. #### Click [here](command:workbench.action.files.saveFiles) to save all this progress.\n    1. #### Click [here](command:workbench.action.terminal.new) to open your vscode terminal. (You may already have one open, that's ok)\n    1. #### Click [here](command:workbench.action.debug.start) to build and deploy the Web App and API.\n    1. #### Click [here](command:auth0.lab.openEndpointByName?[\"Lab: API, Lab: Web App\"]) to launch and view the Web App and API in your web browser.\n\n1. #### Visit the API /reports route in your browser.\nWhile we've successfully wired our API up, it isn't yet secure. You can see this directly by appending the URL for your Expenses API with /reports. \nThe expense data is available publicly, without an Access Token. \n\nIn the next steps, you'll change the API to require a properly-scoped Access Token to view.\nTo do this, we’ll make use of an Express authentication middleware used to protect OAuth2 resources, which validates access tokens.  \n\nLet's secure this API!"

--- a/.auth0/lab/guides/create-the-expenses-api-in-your-labs-tenant.tour
+++ b/.auth0/lab/guides/create-the-expenses-api-in-your-labs-tenant.tour
@@ -3,13 +3,13 @@
   "title": "1: Create the Expenses API in your Auth0 Tenant",
   "steps": [
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Create the Expenses API in Your Labs Tenant",
       "description": "## Create the Expenses API in Your Labs Tenant\n\n1. #### Log into your Auth0 dashboard (You may already be logged in.) \n\n1. #### Make sure you're working in your '_labs_' tenant. \n     ![Select labs tenant](https://cdn.auth0.com/website/a0fun/v2/working-with-apis-0.gif)\n\n1. #### Select the \"_Applications_\" drop-down menu in the left-side navigation, and select \"_APIs_\"\n    ![Open applications menu](https://cdn.auth0.com/website/a0fun/v2/working-with-apis-1.gif)\n\n\n1. #### IMPORTANT: If you see an existing _\"Lab: API\"_ tenant API, follow these steps to delete it. Otherwise, continue on with Step 4. \n    1. #### Select \"_Lab: API_\".   \n       ![delete api](https://cdn.auth0.com/website/a0fun/v2/delete-api-0.gif)  \n    1. #### In the \"_Lab: API_\" settings, scroll to the bottom and select the _Delete_ button.\n       ![delete api button](https://cdn.auth0.com/website/a0fun/v2/delete-api-1.gif)\n    1. #### Type \"_Lab: API_\" in the _Name_ field, then click delete.\n       ![confirm and delete the api](https://cdn.auth0.com/website/a0fun/v2/delete-api-2.gif)\n    1. #### Resume with the next step from _Applications > APIs in the Auth0 Dashboard.\n\n1. #### Click the \"_+ Create API_\" Button.\n\n1. #### Name the API \"_Lab: API_\". (Please ensure this matches exactly)\n\n1. #### For the _Identifier_ field, copy and paste _`\"https://expenses-api\"`_\n\n1. #### Click _Create_.  \n\n    Here's how this should look:\n    \n    ![Create API](https://cdn.auth0.com/website/a0fun/v2/create-labapi.gif)\n\n1. #### Click the _Permissions_ tab. \n\n1. #### Add a new permission called \"_read:reports_\" with a suitable description.\n    This custom permission is the one you will use to determine whether the client is authorized to retrieve expenses.  \n\n    Here's how that should look:\n\n    ![Add Permission](https://cdn.auth0.com/website/a0fun/v2/add-perms.gif)\n\nExcellent. Your API is registered with Auth0."
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Confirm that Your Auth0 Tenant is Configured Appropriately",
       "description": "## Confirm that Your Auth0 Tenant is Configured Appropriately\nNow, you'll use a command to the Auth0 extension for vscode that will reach out to your labs tenant through the CLI and ensure that it is configured appropriately for this lab.\n\n1. #### Click [here](command:auth0.lab.tenantConfigure) to ensure that your Auth0 tenant is configured appropriately for this lab.\n1. #### Click [here](command:workbench.view.extension.auth0-explorer) to open the Auth0 extension and view your tenant configuration. To view details, under APPLICATIONS, you can expand the Lab: Web App. Under APIS, you can expand the Lab: API. \n1. #### Last, click [here](command:workbench.action.files.saveAll) to save all of this progress.\n\nYou're all set to move forward! "

--- a/.auth0/lab/guides/secure-the-expenses-api.tour
+++ b/.auth0/lab/guides/secure-the-expenses-api.tour
@@ -33,13 +33,13 @@
       }
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "API Secured!",
       "description": "## API Secured!\nNice work! \n\nWe’ve now set the Expenses API up with express middleware that will require an authorization token before letting anyone view expenses data.\n\nLet's try it out in the next step!"
     },
     {
-      "file": "README.md",
+      "file": "",
       "line": 1,
       "title": "Call the Secured API Without an Access Token",
       "description": "## Call the Secured API Without an Access Token\n\n1. #### Run the Web Application and Expenses API\n    1. Click [here](command:workbench.action.files.saveFiles) to save all this progress.\n    1. Click [here](command:workbench.action.terminal.new) to open your vscode terminal. (You may already have one open, that's ok.)\n    1. Click [here](command:workbench.action.debug.start) to build and redeploy the API and Web Application.\n    1. Click [here](command:auth0.lab.openEndpointByName?[\"Lab: Web App, Lab: API\"]) to launch the Web Application and the Expenses API in your web browser.\n\n1. #### Log into the Web Application and attempt to navigate to Expenses.\n    Interesting - A 401 error!  \n\n    ![](https://cdn.auth0.com/website/training/example/A0FUN-M06-L01/img-4.png)\n\n    This is expected. The web app is making a call to the API that it is not authorized to access.\n\n    Notice that the home page does not throw an error. This is because we left the “/total” endpoint of the expenses API open to the public. So the web app can still call it to show summary information.\n\n    Similarly, if you attempt to navigate directly to the “/reports” endpoint of the API, you’ll receive an ‘Unauthorized’ error.  \n\n    This is because we’ve successfully secured the API. Now anyone or any application that wishes to consume the “/reports” endpoint _must_ have a valid Access Token.\n\n    All requests that do not include a valid Access Token (expired token, incorrect scopes, etc.) will return an error instead of the desired data.\n\n\n&nbsp;\n\\\nIn the next section, we'll:\n1. Add the Client Secret to the environment\n1. Configure the Web Application to request an access token\n1. Configure the /expenses and /reports endpoints to use the access token"

--- a/.auth0/lab/guides/signin.tour
+++ b/.auth0/lab/guides/signin.tour
@@ -3,7 +3,7 @@
   "title": "0: signin",
   "steps": [
     {
-      "file": "src/web-app/index.js",
+      "file": "",
       "description": "## Sign this Environment into Your Labs Tenant\nBefore getting started, you'll need to sign this Environment into your Auth0 account under the labs tenant. \n\n**IMPORTANT**: If you have not already created a labs tenant, please see the Create a Tenant lab for instructions to do so. \n\n1. #### Click [here](command:auth0.auth.signIn) to sign into your Auth0 account with the Auth0 extension. \n     A browser window will open requesting that you confirm that the code shown matches the one shown in the lower right hand side of your vscode window.\n1. #### Confirm that the values match, then click the **Confirm** button.\n     ![Confirm the values in VS Code](https://cdn.auth0.com/website/a0fun/v2/create-1.gif)\n\n     ![Confirm the values in Auith0](https://cdn.auth0.com/website/a0fun/v2/create-0.gif)\n1. #### Select your labs tenant and click Accept.\n     ![Select the \"labs-\" tenant](https://cdn.auth0.com/website/a0fun/v2/select-0.gif)\n1. #### You should see a success message. Go ahead and close the browser tab.\nNext, you'll set the tenant up with the necessary Application and API to compete this lab.",
       "line": 1
     }

--- a/.auth0/lab/resources.yml
+++ b/.auth0/lab/resources.yml
@@ -4,8 +4,10 @@ clients: # Add other client settings https://auth0.com/docs/api/management/v2#!/
     app_type: "regular_web"
     callbacks:
       - "http://localhost:37500/callback"
+      - "https://*.preview.app.github.dev/callback"
     allowed_logout_urls:
       - "http://localhost:37500"
+      - "https://*.preview.app.github.dev"
     jwt_configuration: 
       alg: "RS256"
       

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "comments.maxHeight": false,  
   "editor.minimap.enabled": false,
   "editor.formatOnSave": false,
     // Enable per-language

--- a/src/api/api/env-config.js
+++ b/src/api/api/env-config.js
@@ -13,6 +13,15 @@ const appUrl = VERCEL_URL
   ? `https://${VERCEL_GITHUB_REPO}-git-${VERCEL_GIT_COMMIT_REF}-${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`
   : `http://localhost:${PORT}`;
 
+function checkEnvironment(){
+  // Use the Codespace App URL if we're in the Codespace environment
+  if(process.env.CODESPACE_NAME){
+    return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+  }
+  // otherwise use the localhost App URL
+  return appUrl;
+}
+
 function checkUrl() {
   return (req, res, next) => {
     const host = req.headers.host;
@@ -38,7 +47,7 @@ console.log("----------------------------------\n");
 
 module.exports = {
   checkUrl,
-  APP_URL: appUrl,
+  APP_URL: checkEnvironment(),
   ISSUER_BASE_URL: removeTrailingSlashFromUrl(ISSUER_BASE_URL),
   AUDIENCE: AUDIENCE,
   PORT: PORT,

--- a/src/web-app/env-config.js
+++ b/src/web-app/env-config.js
@@ -16,6 +16,15 @@ const appUrl = VERCEL_URL
   ? `https://${VERCEL_GITHUB_REPO}-git-${VERCEL_GIT_COMMIT_REF}-${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`
   : `http://localhost:${PORT}`;
 
+  function checkEnvironment(){
+    // Use the Codespace App URL if we're in the Codespace environment
+    if(process.env.CODESPACE_NAME){
+      return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+    }
+    // otherwise use the localhost App URL
+    return appUrl;
+  }
+
 function checkUrl() {
   return (req, res, next) => {
     const host = req.headers.host;
@@ -45,7 +54,7 @@ console.log("----------------------------------\n");
 
 module.exports = {
   checkUrl,
-  APP_URL: appUrl,
+  APP_URL: checkEnvironment(),
   API_URL: removeTrailingSlashFromUrl(API_URL),
   ISSUER_BASE_URL: removeTrailingSlashFromUrl(ISSUER_BASE_URL),
   CLIENT_ID: CLIENT_ID,

--- a/src/web-app/index.js
+++ b/src/web-app/index.js
@@ -30,6 +30,9 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
 app.use(
+  authorizationParams: {
+      response_type: 'code',
+  },
   session({
     secret: SESSION_SECRET,
     resave: false,


### PR DESCRIPTION
When codespaces env is detected, pass the codespaces URL as APP_URL to auth middleware for callback to work


### Testing
#### Test Codespaces env
1. Fork this branch to your Github account
2. Open your fork with Codespaces
3. Follow the CodeTour as normal (Note that you will need to add the Codespaces port forwarding URL in the PORTS tab to the Allowed Callback and Logout URLs rather than localhost--the correct URL is also printed in the debugging console when you launch the app)
4. Added `checkEnvironment()` function in `env-config.js` (for both web app and API) will construct the Codespaces port forwarding URL (based on the condition that we are in Codespaces) and export this value as APP_URL, which is passed to the auth middleware in `index.js` (for both web app and API).
5. Note: The embedded URL rendered in the CodeTour step by the Auth0 labs extension will be incorrect, but the link in the PORTS tab and printed to the debugger will be the correct link. There's an open Auth0 labs extension issue we can look into so that the URL in the CodeTour will be correct regardless of environment: https://github.com/auth0-training/labs-vscode-extension/issues/35

#### Test local env
Since it's also important to test that this change didn't break anything for learners completing this training on their local machine, run through the lab as normal on your local machine to ensure everything works as expected.

